### PR TITLE
prevent double note on touch

### DIFF
--- a/src/game/conductor-performer.js
+++ b/src/game/conductor-performer.js
@@ -316,6 +316,7 @@ export default class ConductorPerformer {
   }
 
   handleTouch (event) {
+    event.preventDefault()
     if (this.isGhostMode) return root.ghostWasSpooked()
     for (let i = 0; i < event.changedTouches.length; i++) {
       const touch = event.changedTouches[i]
@@ -330,6 +331,7 @@ export default class ConductorPerformer {
   }
 
   handleUntouch (event) {
+    event.preventDefault()
     if (!this.isGhostMode) {
       for (let i = 0; i < event.changedTouches.length; i++) {
         const touch = event.changedTouches[i]


### PR DESCRIPTION
This PR prevents the app from playing two notes at the same time when only tapping once on mobile devices.

Bug observed and fixed on Safari on iOS. Not tested on other platforms and browsers.